### PR TITLE
DBの設定を追加(lower_case_table_names=1)

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,2 +1,3 @@
 FROM mariadb:10.6
+COPY custom.cnf /etc/mysql/conf.d
 COPY createDB.sql /docker-entrypoint-initdb.d/

--- a/db/custom.cnf
+++ b/db/custom.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+lower_case_table_names=1


### PR DESCRIPTION
Dockerを使用した場合SQL実行時に発生するエラーを解消
- 原因
  - 問い合わせ時テーブル名の大文字小文字を区別していたため